### PR TITLE
Fix Linux packager

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ More to come...
 
 ## Development
 
+### Requirement for Linux only
+
+We use the package [keytar](http://atom.github.io/node-keytar/) to handle storage of encrypted settings and credentials in your system's keychain.
+Currently, this library uses `libsecret` on Linux platform, so you may need to install it before running `npm ci`:
+* Debian/Ubuntu: sudo apt-get install libsecret-1-dev
+* Red Hat-based: sudo yum install libsecret-devel
+* Arch Linux: sudo pacman -S libsecret
+
 ### Running
 ```
 npm ci

--- a/forge.config.js
+++ b/forge.config.js
@@ -16,11 +16,21 @@ module.exports = {
     },
     {
       name: "@electron-forge/maker-deb",
-      config: {},
+      config: {
+        options: {
+          description: "Quest is a Unified Engine for Searching Things",
+          depends: ["libsecret-1-dev"],
+          homepage: "https://github.com/hverlin/Quest",
+        },
+      },
     },
     {
       name: "@electron-forge/maker-rpm",
-      config: {},
+      config: {
+        description: "Quest is a Unified Engine for Searching Things",
+        requires: ["libsecret-devel"],
+        homepage: "https://github.com/hverlin/Quest",
+      },
     },
   ],
   plugins: [

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "quest",
-  "productName": "Quest",
+  "productName": "quest",
   "private": true,
   "version": "0.0.1",
   "description": "Meta search client",
   "main": ".webpack/main",
+  "license": "MIT",
   "scripts": {
+    "rebuild": "electron-rebuild",
+    "postinstall": "electron-rebuild",
     "start": "rm -rf .webpack && electron-forge start",
     "package": "electron-forge package",
     "make": "rm -rf .webpack && electron-forge make",
@@ -42,6 +45,7 @@
     "css-loader": "^3.4.2",
     "electron": "8.2.0",
     "electron-devtools-installer": "^2.2.4",
+    "electron-rebuild": "^1.10.1",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.3",

--- a/src/main.js
+++ b/src/main.js
@@ -40,7 +40,14 @@ const createWindow = async () => {
     await saveCredential("encryptionKey", encryptionKey);
   }
 
-  if (!isDev && !isAuthenticated && encryptionKey && systemPreferences.canPromptTouchID()) {
+  if (
+    !isDev &&
+    !isAuthenticated &&
+    encryptionKey &&
+    systemPreferences &&
+    systemPreferences.canPromptTouchID &&
+    systemPreferences.canPromptTouchID()
+  ) {
     await systemPreferences.promptTouchID("access your keychain");
   }
 


### PR DESCRIPTION
* Add missing in the `package.json` to make `make` script working on Linux (missing `license`)
* Change the value of the key `productName` because it must be identical to the value of the key `name`
* Add requirements for Linux system in Redmine and in dep/rpm packages
* Handle missing check on `canPromptTouchID` function (not present on Linux)

Signed-off-by: Antoine Chabert <antoine.chabert@tohero.fr>