### PR TITLE
Make Redmine API Key a password field in settings

### DIFF
--- a/src/configuration-schema.json
+++ b/src/configuration-schema.json
@@ -400,7 +400,8 @@
               "apiKey": {
                 "title": "API Key",
                 "type": "string",
-                "default": ""
+                "default": "",
+                "x-component": "password"
               },
               "pageSize": {
                 "title": "Number of results per page",


### PR DESCRIPTION
To fix the issue #14

Signed-off-by: Antoine Chabert <antoine.chabert@tohero.fr>