### PR TITLE
Use ES6 Arrow Functions

### DIFF
--- a/src/modules/gmail/index.js
+++ b/src/modules/gmail/index.js
@@ -138,9 +138,7 @@ function b64DecodeUnicode(str) {
   return decodeURIComponent(
     atob(str.replace(/_/g, "/").replace(/-/g, "+"))
       .split("")
-      .map(function (c) {
-        return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
-      })
+      .map(c => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
       .join("")
   );
 }


### PR DESCRIPTION
**Arrow functions are a more concise syntax that can replace the full function syntax in many cases.** For example, `function(x, y) { return x * y }` can be replaced with `(x, y) => { return x * y; }`.

Arrow functions are slightly different from regular functions, because they do not have bindings to the `this`, `arguments`, `super` or `new.target` keywords.

An additional codemod can be used as a follow-up to simplify single-statement arrow functions.